### PR TITLE
fix bug that the min and max elem in  function middleSplit_ is  wrong sometimes.

### DIFF
--- a/include/nanoflann.hpp
+++ b/include/nanoflann.hpp
@@ -1300,6 +1300,10 @@ class KDTreeBaseClass
         ElementType max_spread = -1;
         cutfeat                = 0;
         ElementType min_elem = 0, max_elem = 0;
+
+        if (max_span == 0)
+            computeMinMax(obj, ind, count, cutfeat, min_elem, max_elem);
+                
         for (Dimension i = 0; i < dims; ++i)
         {
             ElementType span = bbox[i].high - bbox[i].low;


### PR DESCRIPTION


if  span of all dimensions  is 0, then  condition(span > (1 - EPS) * max_span) is always false, the  min_elem and max_elem are always the default initailized value 0, even 0 is not the member of dataset.  This bug could be occur while there all the points which has the same location(x,y,z).